### PR TITLE
Refactor ReppoRegistry and ModelContract

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
-  
+
       - uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 
       - name: Check formatting
         run: forge fmt --check
-  
+
       - name: Forge test
         run: forge test

--- a/contracts/src/ModelContract.sol
+++ b/contracts/src/ModelContract.sol
@@ -15,9 +15,12 @@ contract ModelContract is CallbackConsumer {
 
     address public reppoRegistry;
 
-    constructor(address registry, string memory _modelName, address _reppoRegistry) CallbackConsumer(registry) {
-        modelName = _modelName;
+    constructor(address registry, address _reppoRegistry) CallbackConsumer(registry) {
         reppoRegistry = _reppoRegistry;
+    }
+
+    function setModelName(string memory _modelName) public {
+        modelName = _modelName;
     }
 
     function setPaymentToken(address _paymentToken) public {
@@ -28,7 +31,7 @@ contract ModelContract is CallbackConsumer {
         paymentAmount = _paymentAmount;
     }
 
-    function requestInference() public {
+    function requestInference(bytes memory input) public {
         if (address(paymentToken) != address(0x0)) {
             paymentToken.transferFrom(msg.sender, address(this), paymentAmount * 9 / 10);
             paymentToken.transferFrom(msg.sender, reppoRegistry, paymentAmount * 1 / 10);
@@ -36,7 +39,7 @@ contract ModelContract is CallbackConsumer {
 
         _requestCompute(
             modelName,
-            bytes("Good morning!"),
+            input,
             1, // redundancy
             address(0), // paymentToken
             0, // paymentAmount

--- a/contracts/src/ReppoRegistry.sol
+++ b/contracts/src/ReppoRegistry.sol
@@ -17,7 +17,8 @@ contract ReppoRegistry {
     }
 
     function register(string memory modelName) public returns (address) {
-        ModelContract modelContract = new ModelContract(ritualRegistry, modelName, address(this));
+        ModelContract modelContract = new ModelContract(ritualRegistry, address(this));
+        modelContract.setModelName(modelName);
 
         ownerToModel[msg.sender] = address(modelContract);
 
@@ -26,9 +27,9 @@ contract ReppoRegistry {
         return address(modelContract);
     }
 
-    function requestInference(address _modelContract) public {
+    function requestInference(address _modelContract, bytes memory input) public {
         ModelContract modelContract = ModelContract(_modelContract);
-        modelContract.requestInference();
+        modelContract.requestInference(input);
     }
 
     function setPaymentToken(address _modelContract, address _paymentToken) public {

--- a/contracts/test/ModelContract.d.sol
+++ b/contracts/test/ModelContract.d.sol
@@ -45,7 +45,7 @@ contract ModelContractTest is Test {
         assertEq(paymentToken.balanceOf(address(modelContract.reppoRegistry())), 0 ether);
         assertEq(address(modelContract.paymentToken()), address(0x0));
 
-        modelContract.requestInference();
+        modelContract.requestInference(bytes(""));
 
         assertEq(paymentToken.balanceOf(address(modelContract)), 0 ether);
         assertEq(paymentToken.balanceOf(address(modelContract.reppoRegistry())), 0 ether);
@@ -59,7 +59,7 @@ contract ModelContractTest is Test {
         assertEq(modelContract.paymentAmount(), 10 ether);
         assertEq(paymentToken.balanceOf(address(modelContract)), 0);
 
-        modelContract.requestInference();
+        modelContract.requestInference(bytes(""));
 
         assertEq(paymentToken.balanceOf(address(modelContract)), 9 ether);
         assertEq(paymentToken.balanceOf(address(modelContract.reppoRegistry())), 1 ether);


### PR DESCRIPTION
Why:
* The ModelContract was not allowing user input to the
  `requestInference` function
* This change also makes the ModelContract verifiable as it no longer
  depends on user input for the constructor arguments

How:
* Removing the hardcoded input in the `requestInference` function to use
  user input instead
* Adding a `setModelName` function that is called from the ReppoRegistry
  `register` function to set the model name instead of relying on
  constructor arguments
* Updating tests to reflect the changes
