### PR TITLE
Allow using ETH as payment for inference

### DIFF
--- a/contracts/src/ModelContract.sol
+++ b/contracts/src/ModelContract.sol
@@ -10,6 +10,7 @@ contract ModelContract is CallbackConsumer {
 
     bytes[] public outputs;
 
+    uint256 public paymentAmountInETH;
     uint256 public paymentAmount;
     IERC20 public paymentToken;
 
@@ -31,10 +32,30 @@ contract ModelContract is CallbackConsumer {
         paymentAmount = _paymentAmount;
     }
 
+    function setPaymentAmountInETH(uint256 _paymentAmountInETH) public {
+        paymentAmountInETH = _paymentAmountInETH;
+    }
+
     function requestInference(bytes memory input) public {
         if (address(paymentToken) != address(0x0)) {
             paymentToken.transferFrom(msg.sender, address(this), paymentAmount * 9 / 10);
             paymentToken.transferFrom(msg.sender, reppoRegistry, paymentAmount * 1 / 10);
+        }
+
+        _requestCompute(
+            modelName,
+            input,
+            1, // redundancy
+            address(0), // paymentToken
+            0, // paymentAmount
+            address(0), // wallet
+            address(0) // prover
+        );
+    }
+
+    function requestInferenceWithETH(bytes memory input) public payable {
+        if (paymentAmountInETH != 0) {
+            require(msg.value >= paymentAmountInETH, "not enough payment in ETH");
         }
 
         _requestCompute(

--- a/contracts/src/ReppoRegistry.sol
+++ b/contracts/src/ReppoRegistry.sol
@@ -32,6 +32,11 @@ contract ReppoRegistry {
         modelContract.requestInference(input);
     }
 
+    function requestInferenceWithETH(address _modelContract, bytes memory input) public payable {
+        ModelContract modelContract = ModelContract(_modelContract);
+        modelContract.requestInferenceWithETH(input);
+    }
+
     function setPaymentToken(address _modelContract, address _paymentToken) public {
         ModelContract modelContract = ModelContract(_modelContract);
         modelContract.setPaymentToken(_paymentToken);

--- a/contracts/test/ModelContract.d.sol
+++ b/contracts/test/ModelContract.d.sol
@@ -64,4 +64,14 @@ contract ModelContractTest is Test {
         assertEq(paymentToken.balanceOf(address(modelContract)), 9 ether);
         assertEq(paymentToken.balanceOf(address(modelContract.reppoRegistry())), 1 ether);
     }
+
+    function test_ExecuteWithETHPayment() public {
+        modelContract.setPaymentAmountInETH(1 ether);
+
+        assertEq(modelContract.paymentAmountInETH(), 1 ether);
+
+        modelContract.requestInferenceWithETH{value: 1 ether}(bytes(""));
+
+        assertEq(address(modelContract).balance, 1 ether);
+    }
 }


### PR DESCRIPTION
Why:
* Issue #25

How:
* Adding a new `payable` function that receives ETH to trigger inference
* Allow setting the minimum payment amount in ETH to trigger inference
